### PR TITLE
added limited array compatibility + minimal array init example

### DIFF
--- a/Py_XPPCALL_Example5.py
+++ b/Py_XPPCALL_Example5.py
@@ -1,0 +1,99 @@
+"""
+another example with the other init syntax + array init
+
+"""
+
+# import some modules including Py_XPPCALL
+import matplotlib.pylab as plt
+import numpy as np
+from xppcall import xpprun, read_pars, read_inits, read_numerics
+
+# check if parameters with label 'p' will work
+# add function to change inits.
+
+# Let's check what are the parameters of the model
+pars = read_pars('schnakenberg.ode')
+print 'pars',pars
+
+# print inits
+inits = read_inits('schnakenberg.ode')
+print 'default inits',inits
+
+# print options
+numerics = read_numerics('schnakenberg.ode')
+print 'numerics', numerics
+
+
+# run ODE and get solution with default inits
+
+# Let's plot a solution with default parameters and inits specified in the .ODE file
+npa, vn = xpprun('schnakenberg.ode', clean_after=True)
+t = npa[:,0]
+sv = npa[:,1:] #(501 time steps, 202 variables)
+
+# the way that xpp defined the ODEs, the varnames alternate like u0,v0,u1,v1,u2,v2,... u99,v99,u100,v100
+
+#print np.shape(sv)
+
+fig = plt.figure(figsize=(10,5))
+ax1 = fig.add_subplot(121)
+ax1.set_title('default inits and params')
+ax1.plot(sv[:,0],sv[:,1],lw=2)
+#ax1.set_xlim([-1.05,1.05])
+#ax1.set_ylim([-1.05,1.05])
+#ax1.set_title('q=1')
+
+
+# modify a param
+npa, vn = xpprun('schnakenberg.ode', parameters={'a':5}, clean_after=True)
+t = npa[:,0]
+sv = npa[:,1:]
+
+ax2 = fig.add_subplot(122)
+ax2.set_title('default inits and new param (a)')
+ax2.plot(sv[:,0],sv[:,1],lw=2)
+#ax2.set_xlim([-1.05,1.05])
+#ax2.set_ylim([-1.05,1.05])
+#ax2.set_title('q=5')
+
+
+
+
+# now let's modify an entire array of initial conditions
+# the index number must correspond to the number in the xpp array. e.g. if 
+# init u[3..100] then we must define a list with 98 elements
+npa, vn = xpprun('schnakenberg.ode', inits={'u':[1.,2.]}, clean_after=False)
+t = npa[:,0]
+sv = npa[:,1:]
+
+
+fig2 = plt.figure(figsize=(10,5))
+ax1 = fig2.add_subplot(121)
+ax1.set_title('new inits with default params')
+ax1.plot(sv[:,0],sv[:,1],lw=2)
+
+npa, vn = xpprun('schnakenberg.ode', inits={'u':[1.,2.]}, parameters={'a':5}, clean_after=True)
+t = npa[:,0]
+sv = npa[:,1:]
+
+
+ax2 = fig2.add_subplot(122)
+ax2.set_title('new inits with new param (a)')
+ax2.plot(sv[:,0],sv[:,1],lw=2)
+
+"""
+# example with different initial conditions
+npa, vn = xpprun('simple2.ode', inits={'u':-.1,'v':-.2}, clean_after=False)
+t = npa[:,0]
+sv = npa[:,1:]
+
+fig = plt.figure()
+
+ax3 = fig.add_subplot(111)
+ax3.plot(sv[:,vn.index('u')],sv[:,vn.index('v')])
+
+ax3.set_xlim([-1.05,1.05])
+ax3.set_ylim([-1.05,1.05])
+ax3.set_title('Lambda-Omega System')
+"""
+plt.show()

--- a/schnakenberg.ode
+++ b/schnakenberg.ode
@@ -1,0 +1,22 @@
+# example taken from http://www.math.pitt.edu/~bard/xpp/help/xppexample.html
+
+# schnakenberg PDE 5 points
+# interlaced
+f(u,v)=-u+v*u^2
+g(u,v)=a-v*u^2
+u0'=f(u0,v0)+duh*(u1-u0)
+v0'=g(u0,v0)+dvh*(v1-v0)
+%[1..3]
+u[j]'=f(u[j],v[j])+duh*(u[j+1]-2*u[j]+u[j-1])
+v[j]'=g(u[j],v[j])+dvh*(v[j+1]-2*v[j]+v[j-1])
+%
+u4'=f(u4,v4)+duh*(u3-u4)
+v4'=g(u4,v4)+dvh*(v3-v4)
+par a=1.05,du=5,dv=75,h=.2
+!duh=du/(h*h)
+!dvh=dv/(h*h)
+init u0=1.5,u1=1.3,u2=1.1,v0=1.05,v1=1.05,v2=1.05
+init u[3..4]=1.05,v[3..4]=1.05
+@ dt=.1,nout=50,total=50,meth=cvode,tol=1e-5,atol=1e-5
+@ bandlo=2,bandup=2
+done

--- a/simple3.ode
+++ b/simple3.ode
@@ -1,0 +1,20 @@
+# array initial condition
+
+u'=lam*u-om*v
+v'=lam*v+om*u
+
+r = sqrt(u^2+v^2)
+lam=1-r^2
+om=1+q*(r^2-1)
+
+p q=1
+
+u(0 )=.2
+v(0)=.5
+
+@ dt=.01,total=100
+
+
+
+
+d


### PR DESCRIPTION
Also fixed minor issue with scalar inits.

In python, the initial conditions must be input as a list and must match the length of the xpp array syntax. by that i mean if

init x0=3
init x[1..3]=1

then you can modify the initial conditions like inits={'x':[11,21,13],'x0':5}. This will change the initial conditions into explicit scalar initial values, i.e, change to

init x0=5
init x1=11,x2=21,x3=13

The limitation is that xpp can not parse one line of an ode file past a certain character limit so this method is limited to around 20 initial conditions depending on the character size of the variables and values.  (I'm not sure what the character limit is, but it's big enough for small arrays and good enough for now). 